### PR TITLE
feat: bring back old getting new offers logic and add `requiredSkills` as db entity

### DIFF
--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -14,15 +14,15 @@ datasource db {
 }
 
 model B2BOffer {
-  id             Int      @id @default(autoincrement())
-  createdAt      DateTime @default(now())
+  id             Int         @id @default(autoincrement())
+  createdAt      DateTime    @default(now())
   slug           String
   title          String
   url            String
   city           String
   fromPln        Float
   toPln          Float
-  requiredSkills String
+  requiredSkills SearchTag[]
   companyName    String
   publishedAt    DateTime
 }
@@ -64,4 +64,5 @@ model SearchTag {
   name                 String                @id @unique
   emailNotifications   EmailNotification[]
   discordNotifications DiscordNotification[]
+  b2bOffers            B2BOffer[]
 }

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -18,7 +18,7 @@ model B2BOffer {
   createdAt      DateTime @default(now())
   slug           String
   title          String
-  url            String   @unique
+  url            String
   city           String
   fromPln        Float
   toPln          Float

--- a/apps/api/src/controllers/offers.ts
+++ b/apps/api/src/controllers/offers.ts
@@ -3,7 +3,7 @@ export * from "./notification";
 import { offersService } from "@fetcher-api/services";
 import type { Handler } from "hono";
 
-const { getNewOffers } = offersService;
+const { getNewOffers, getAllSearchTags } = offersService;
 
 const getNewOffersController: Handler = async c => {
   const { tags } = c.req.query();
@@ -13,4 +13,13 @@ const getNewOffersController: Handler = async c => {
   return c.json({ data: response });
 };
 
-export const offersController = { getNewOffersController };
+const getAllSearchTagsController: Handler = async c => {
+  const response = await getAllSearchTags();
+
+  return c.json({ data: response.map(tag => tag.name) });
+};
+
+export const offersController = {
+  getNewOffersController,
+  getAllSearchTagsController,
+};

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -60,6 +60,7 @@ cron.schedule(
   async () => {
     try {
       await scrapingService.scrapeAll();
+      await offersService.clearMoreThan7DaysOldOffers();
     } catch (e) {
       if (e instanceof Error) {
         await serviceLogger.sendErrorMessage({

--- a/apps/api/src/models/offers.ts
+++ b/apps/api/src/models/offers.ts
@@ -16,23 +16,41 @@ const getNewOffersFromDB = async (tags: string[]) => {
     url: true,
     fromPln: true,
     toPln: true,
-    publishedAt: true,
   };
 
-  const newOffers = await prisma.b2BOffer.findMany({
+  const past7DaysOffers = await prisma.b2BOffer.findMany({
     where: {
-      publishedAt: {
-        gte: today.minus({ day: 1 }).toJSDate(),
-        lt: today.plus({ day: 1 }).toJSDate(),
+      createdAt: {
+        gte: today.minus({ days: 7 }).toJSDate(),
+        lt: today.toJSDate(),
       },
       AND: {
         OR: tags.map(tech => ({
-          requiredSkills: { contains: `${tech},`, mode: "insensitive" },
+          requiredSkills: { contains: tech, mode: "insensitive" },
         })),
       },
     },
     select: fieldsToSelect,
   });
+
+  const todayOffers = await prisma.b2BOffer.findMany({
+    where: {
+      createdAt: {
+        gte: today.toJSDate(),
+        lt: today.plus({ day: 1 }).toJSDate(),
+      },
+      AND: {
+        OR: tags.map(tech => ({
+          requiredSkills: { contains: tech, mode: "insensitive" },
+        })),
+      },
+    },
+    select: fieldsToSelect,
+  });
+
+  const newOffers = todayOffers.filter(
+    offer => !past7DaysOffers.find(yOffer => yOffer.url === offer.url)
+  );
 
   return newOffers;
 };

--- a/apps/api/src/routes/offers.ts
+++ b/apps/api/src/routes/offers.ts
@@ -3,8 +3,9 @@ import { offersController } from "../controllers/offers";
 
 const api = new Hono();
 
-const { getNewOffersController } = offersController;
+const { getNewOffersController, getAllSearchTagsController } = offersController;
 
 api.get("/new", getNewOffersController);
+api.get("/tags", getAllSearchTagsController); //@TODO search tags should be another MVC structure
 
 export const offersRouter = api;

--- a/apps/api/src/scraper-modules/jj-it/jj-it-scraper.ts
+++ b/apps/api/src/scraper-modules/jj-it/jj-it-scraper.ts
@@ -50,15 +50,7 @@ export const scrapeJJIt = async (client: PrismaClient) => {
       })) ?? [],
   };
 
-  await client.$transaction(
-    offers.data.map(offer =>
-      client.b2BOffer.upsert({
-        where: { url: offer.url },
-        update: offer,
-        create: offer,
-      })
-    )
-  );
+  await client.b2BOffer.createMany(offers);
 
   return offers.data;
 };

--- a/apps/api/src/scraper-modules/no-fluff-jobs/no-fluff-jobs-scraper.ts
+++ b/apps/api/src/scraper-modules/no-fluff-jobs/no-fluff-jobs-scraper.ts
@@ -63,15 +63,7 @@ export const scrapeNoFluffJobs = async (client: PrismaClient) => {
       })) ?? [],
   };
 
-  await client.$transaction(
-    offers.data.map(offer =>
-      client.b2BOffer.upsert({
-        where: { url: offer.url },
-        update: offer,
-        create: offer,
-      })
-    )
-  );
+  await client.b2BOffer.createMany(offers);
 
   return offers.data;
 };

--- a/apps/api/src/services/notification.ts
+++ b/apps/api/src/services/notification.ts
@@ -2,7 +2,7 @@ import { sendDiscordWebhookMessage } from "@fetcher-api/utils";
 import { EmbedBuilder } from "discord.js";
 import { DateTime } from "luxon";
 import { notificationModel } from "../models/notification";
-import { offersModel } from "../models/offers";
+import { offersModel, type OffersWithTags } from "../models/offers";
 
 const OFFERS_PER_MESSAGE = 10;
 
@@ -10,15 +10,6 @@ const notificationMessageBase = {
   username: "Daily Offers",
   avatarURL:
     "https://upload.wikimedia.org/wikipedia/commons/4/48/Robert_Maklowicz_2014_%28cropped%29.jpg",
-};
-
-type Offer = {
-  createdAt: Date;
-  title: string;
-  url: string;
-  fromPln: number;
-  toPln: number;
-  requiredSkills: string;
 };
 
 const {
@@ -90,7 +81,7 @@ export const notificationService = {
   sendSingleDiscordNotification,
 };
 
-const getEmbeds: (offer: Offer[]) => EmbedBuilder[] = offers => {
+const getEmbeds: (offers: OffersWithTags) => EmbedBuilder[] = offers => {
   //make each segment max 25 to satisfy embed max field rule
   const embeds = offers.reduce((acc, next, index) => {
     if (!acc.length || index % OFFERS_PER_MESSAGE === 0) {
@@ -106,9 +97,11 @@ const getEmbeds: (offer: Offer[]) => EmbedBuilder[] = offers => {
   return embeds;
 };
 
-const getEmbedContent = (offer: Offer) => ({
+const getEmbedContent = (offer: OffersWithTags[0]) => ({
   name: offer.title,
-  value: `Skills: ${offer.requiredSkills}\nFrom: ${offer.fromPln} PLN, To: ${offer.toPln} PLN\n[Link](${offer.url})`,
+  value: `Skills: ${offer.requiredSkills.map(i => i.name).join(",")}\nFrom: ${
+    offer.fromPln
+  } PLN, To: ${offer.toPln} PLN\n[Link](${offer.url})`,
 });
 
 const _sendDiscordNotification = async (

--- a/apps/api/src/services/offers.ts
+++ b/apps/api/src/services/offers.ts
@@ -1,11 +1,17 @@
 import { offersModel } from "@fetcher-api/models";
 
-const { getNewOffersFromDB, clearMoreThan7DaysOldOffersFromDB } = offersModel;
+const {
+  getNewOffersFromDB,
+  clearMoreThan7DaysOldOffersFromDB,
+  getAllSearchTagsFromDB,
+} = offersModel;
 
 const getNewOffers = getNewOffersFromDB;
 const clearMoreThan7DaysOldOffers = clearMoreThan7DaysOldOffersFromDB;
+const getAllSearchTags = getAllSearchTagsFromDB;
 
 export const offersService = {
   getNewOffers,
+  getAllSearchTags,
   clearMoreThan7DaysOldOffers,
 };


### PR DESCRIPTION
# Description

* bringing back old logic for getting offers, new one was too much dependant on the services providing the offers because of the `publishedAt` prop (resulted in a lot of offers being returned from the search)
* changed `requiredSkills` to be of `searchTag` type

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:

- Firmware version:
- Hardware:
- Toolchain:
- SDK:

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
